### PR TITLE
More details in README, sort requirements and remove pytket*

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # pytemplate
 
-This is a Python 3.11 app called pytemplate. It uses toml instead of setup.py for configuration. The project includes Docker, Pyright, Ruff, GitHub Actions, Black and pre-commit, and Sphinx.
+This is a Python 3.11 app called pytemplate. It uses toml instead of setup.py for configuration. The project includes Docker, Pyright, Ruff, GitHub Actions, Black, pre-commit, and Sphinx.
 
 ## Project Structure
 
 The project structure is as follows:
 
-```
+```sh
 pytemplate
 ├── .github
 │   └── workflows
@@ -49,4 +49,22 @@ The project includes GitHub Actions for continuous integration, with the configu
 
 ## Installation
 
-To install the project, clone the repository and run `pip install -r requirements.txt`.
+To install the project, clone the repository and run:
+
+```sh
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip setuptools
+pip install -r requirements.txt
+pre-commit install
+```
+
+Then install the project using:
+
+```sh
+pip install -e .
+```
+
+## Testing
+
+Just issue `pytest` from the root directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "Author", email = "author@email.com" }]
 where = ["pytemplate"]
 
 [tool.ruff]
-# Enable flake8-bugbear (`B`) rules, pandas, see https://beta.ruff.rs/docs/rules/
+# See https://beta.ruff.rs/docs/rules/
 select = ["E", "F", "B", "RUF", "PT", "UP", "C4", "D"]
 extend-exclude = ["**/*.ipynb"]
 target-version = "py311"
@@ -21,9 +21,14 @@ target-version = "py311"
 # Use Google-style docstrings.
 convention = "google"
 
-#https://microsoft.github.io/pyright/#/getting-started
+# See https://microsoft.github.io/pyright/#/getting-started
 [tool.pyright]
 include = ["pytemplate","tests"]
 ignore = ["**/*.ipynb"]
 pythonVersion = "3.11"
 typeCheckingMode = "strict"
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-pyright
 black
-sphinx
-pytket
-pytket-qiskit
 pre-commit
-wheel
+pyright
 pytest
 pytest-lazy-fixture
+sphinx
+wheel


### PR DESCRIPTION
I think `pytket` and especially `pytket-qiskit` need not be in the template project.

I also updated instructions to use a virtual environment by default.