### PR TITLE
ci: add python package grouping to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This change should avoid multiple PRs for dep updates such as #36 and #35 on the same day.